### PR TITLE
Fix/w32 modules ref

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# JetBrains
+.idea
+# Visual Studio
+.vs
+# Visual Studio Code
+.vscode
+
+# produced by go mod
+go.sum

--- a/draw/window_windows.go
+++ b/draw/window_windows.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gonutz/d3d9"
 	"github.com/gonutz/mixer"
 	"github.com/gonutz/mixer/wav"
-	"github.com/gonutz/w32"
+	"github.com/gonutz/w32/v2"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/gonutz/prototype
+
+go 1.16
+
+require (
+	github.com/gonutz/d3d9 v1.2.1
+	github.com/gonutz/gl v0.0.0-20200331132851-5b79a12b1985
+	github.com/gonutz/glfw v0.0.0-20200331133027-cde2e32806b8
+	github.com/gonutz/go-sdl2 v0.4.1
+	github.com/gonutz/mixer v1.0.0
+	github.com/gonutz/w32/v2 v2.2.0
+	github.com/veandco/go-sdl2 v0.4.5 // indirect
+)


### PR DESCRIPTION
Prototype references github.com/gonutz/w32 which, with modules, fetches the v1.0.0 version that does not build. This change updates prototype to build with go 1.15 and 1.16 in a fresh environment.

Testing:
- reimaged a vm, win 10 2020 h2
- installed git, go,
- clone github.com/kfsone/prototype into $env:GOPATH/src/github.com/gonutz/prototype and checked out the fix/w32-modules-ref branch
- execute the following steps:

```ps1
    $nutzdir = Join-Path $env:GOPATH src/github.com/gonutz
    $srcurl = "https://raw.githubusercontent.com/gonutz/prototype/master/samples/worm/worm.go"

    cd (mkdir (join-path $nutzdir proto.before))
    invoke-webrequest $srcurl -outfile worm.go  # iwr for short
    go run worm.go

    # go 1.16 fails because no modules stuff
    go mod init ; go mod tidy
    go run worm.go
```

fails:

	# github.com/gonutz/prototype/draw
	..\..\..\..\pkg\mod\github.com\gonutz\prototype@v0.0.0-20210219081453-295a54f2a887\draw\window_windows.go:93:8: undefined: w32.UnregisterClassAtom
	..\..\..\..\pkg\mod\github.com\gonutz\prototype@v0.0.0-20210219081453-295a54f2a887\draw\window_windows.go:442:7: undefined: w32.WM_MOUSEHWHEEL
	..\..\..\..\pkg\mod\github.com\gonutz\prototype@v0.0.0-20210219081453-295a54f2a887\draw\window_windows.go:515:10: cannot use style & ^w32.WS_OVERLAPPEDWINDOW (type int32) as type uint32 in argument to w32.SetWindowLong

then I used go mod edit to switch to using the local on-disk copy of prototype:

```ps1
    cd (mkdir (Join-Path $testdir proto.after))
    iwr $srcurl -outfile worm.go

    go mod init
    # --vv--
    go mod edit -replace github.com/gonutz/prototype=../../gonutz/prototype  ## <<
    # --^^--
    go mod tidy
    go run worm.go
```

which works

![image](https://user-images.githubusercontent.com/323009/109227966-0180da00-7776-11eb-9778-168459eab8ed.png)

